### PR TITLE
For HTML files, encode tag opening and closing characters

### DIFF
--- a/src/ghembedder.js
+++ b/src/ghembedder.js
@@ -226,6 +226,11 @@ ghe._jsonpCallback = function(key){
 			lib.data = resp.data;
 			
 			decoded = ghe._decodeContent( resp.data.content );
+			//check if the file is htm(l)
+			if (lib.fileName.match(/.*\.htm[l]*$/)){
+				//replace the tags so that they will be interpreted as text, and not source
+				decoded = decoded.replace(/</g,"&lt;").replace(/>/g,"&gt;");
+			}
 			lines = decoded.split('\n');
 			
 			if( hasLineRange ){


### PR DESCRIPTION
When I use HTML files I notice that the code is interpreted as source when embedded so it doesn't get shown (i.e. <!-- won't show up -->).

As a solution, I check the filename to see if it ends with .htm or .html and if so I replace the opening and closing characters (< , >) with their HTML encoded equivalents (&lt; , &gt;) so that the HTML source code will appear correctly.

There may be a better way, or place, to do this, but the code in the pull request is concise and works for me.

Thanks for this script, by the way.
