### PR TITLE
escape html tags if lang has 'html'

### DIFF
--- a/src/ghembedder.js
+++ b/src/ghembedder.js
@@ -227,7 +227,7 @@ ghe._jsonpCallback = function(key){
 			
 			decoded = ghe._decodeContent( resp.data.content );
 			//check if the file is htm(l)
-			if (lib.fileName.match(/.*\.htm[l]*$/)){
+			if (lib.fileName.match(/.*\.htm[l]*$/) || lib.lang.match(/html/)){
 				//replace the tags so that they will be interpreted as text, and not source
 				decoded = decoded.replace(/</g,"&lt;").replace(/>/g,"&gt;");
 			}

--- a/src/ghembedder.js
+++ b/src/ghembedder.js
@@ -227,10 +227,8 @@ ghe._jsonpCallback = function(key){
 			
 			decoded = ghe._decodeContent( resp.data.content );
 			//check if the file is htm(l)
-			if (lib.fileName.match(/.*\.htm[l]*$/) || lib.lang.match(/html/)){
-				//replace the tags so that they will be interpreted as text, and not source
-				decoded = decoded.replace(/</g,"&lt;").replace(/>/g,"&gt;");
-			}
+			//replace the tags so that they will be interpreted as text, and not source
+			decoded = decoded.replace(/</g,"&lt;").replace(/>/g,"&gt;");
 			lines = decoded.split('\n');
 			
 			if( hasLineRange ){


### PR DESCRIPTION
I have some JSX files I want to embed on my blog, and I need to html encode the source. I think this is the easiest way to make it possible.

PS: I tried running the grunt task, but kept getting errors, so I'm just sending the source file edit.
